### PR TITLE
Fixing issues with linker files

### DIFF
--- a/4T.pdb
+++ b/4T.pdb
@@ -1,0 +1,296 @@
+TITLE     Displayed atoms
+REMARK   4      COMPLIES WITH FORMAT V. 3.0, 1-DEC-2006
+REMARK 888
+REMARK 888 WRITTEN BY MAESTRO (A PRODUCT OF SCHRODINGER, LLC)
+ATOM      1  P    DT B   2      -1.916   8.868   6.898  1.00  0.00           P  
+ATOM      2  OP1  DT B   2      -0.793   9.774   7.228  1.00  0.00           O  
+ATOM      3  OP2  DT B   2      -3.047   8.873   7.852  1.00  0.00           O1-
+ATOM      4  O5'  DT B   2      -2.450   9.183   5.423  1.00  0.00           O  
+ATOM      5  C5'  DT B   2      -1.692   8.717   4.292  1.00  0.00           C  
+ATOM      6  C4'  DT B   2      -1.908   9.638   3.107  1.00  0.00           C  
+ATOM      7  O4'  DT B   2      -3.101   9.208   2.387  1.00  0.00           O  
+ATOM      8  C3'  DT B   2      -2.177  11.104   3.445  1.00  0.00           C  
+ATOM      9  C2'  DT B   2      -3.689  11.130   3.663  1.00  0.00           C  
+ATOM     10  C1'  DT B   2      -4.173  10.104   2.644  1.00  0.00           C  
+ATOM     11  N1   DT B   2      -5.341   9.304   3.106  1.00  0.00           N  
+ATOM     12  C2   DT B   2      -6.269   8.946   2.158  1.00  0.00           C  
+ATOM     13  O2   DT B   2      -6.169   9.254   0.983  1.00  0.00           O  
+ATOM     14  N3   DT B   2      -7.337   8.206   2.625  1.00  0.00           N  
+ATOM     15  C4   DT B   2      -7.550   7.803   3.927  1.00  0.00           C  
+ATOM     16  O4   DT B   2      -8.546   7.142   4.226  1.00  0.00           O  
+ATOM     17  C5   DT B   2      -6.522   8.226   4.849  1.00  0.00           C  
+ATOM     18  C7   DT B   2      -6.674   7.832   6.288  1.00  0.00           C  
+ATOM     19  C6   DT B   2      -5.471   8.948   4.423  1.00  0.00           C  
+ATOM     20  H3   DT B   2      -7.998   7.946   1.986  1.00  0.00           H  
+ATOM     21 1H5'  DT B   2      -0.632   8.701   4.544  1.00  0.00           H  
+ATOM     22 2H5'  DT B   2      -2.016   7.710   4.027  1.00  0.00           H  
+ATOM     23  H4'  DT B   2      -1.065   9.553   2.421  1.00  0.00           H  
+ATOM     24  H3'  DT B   2      -1.499  11.425   4.237  1.00  0.00           H  
+ATOM     25 1H2'  DT B   2      -3.913  10.847   4.692  1.00  0.00           H  
+ATOM     26 2H2'  DT B   2      -4.067  12.134   3.471  1.00  0.00           H  
+ATOM     27  H1'  DT B   2      -4.501  10.555   1.707  1.00  0.00           H  
+ATOM     28  H71  DT B   2      -5.830   8.217   6.862  1.00  0.00           H  
+ATOM     29  H72  DT B   2      -7.601   8.247   6.683  1.00  0.00           H  
+ATOM     30  H73  DT B   2      -6.699   6.745   6.367  1.00  0.00           H  
+ATOM     31  H6   DT B   2      -4.721   9.247   5.141  1.00  0.00           H  
+ATOM     32 HC3'  DT B   2      -1.958  11.697   2.557  1.00  0.00           H  
+ATOM     33 P*    DT B   3      -3.671   3.090   9.276  1.00  0.00           P  
+ATOM     34  OP1  DT B   3      -2.860   3.640  10.386  1.00  0.00           O  
+ATOM     35  OP2  DT B   3      -5.127   2.997   9.528  1.00  0.00           O1-
+ATOM     36  O5'  DT B   3      -3.406   3.933   7.943  1.00  0.00           O  
+ATOM     37  C5'  DT B   3      -2.185   3.715   7.209  1.00  0.00           C  
+ATOM     38  C4'  DT B   3      -1.789   4.981   6.475  1.00  0.00           C  
+ATOM     39  O4'  DT B   3      -2.468   5.009   5.186  1.00  0.00           O  
+ATOM     40  C3'  DT B   3      -2.192   6.293   7.145  1.00  0.00           C  
+ATOM     41  O3'  DT B   3      -1.384   7.373   6.687  1.00  0.00           O  
+ATOM     42  C2'  DT B   3      -3.615   6.513   6.629  1.00  0.00           C  
+ATOM     43  C1'  DT B   3      -3.528   5.953   5.214  1.00  0.00           C  
+ATOM     44  N1   DT B   3      -4.770   5.265   4.764  1.00  0.00           N  
+ATOM     45  C2   DT B   3      -5.106   5.384   3.437  1.00  0.00           C  
+ATOM     46  O2   DT B   3      -4.437   6.018   2.639  1.00  0.00           O  
+ATOM     47  N3   DT B   3      -6.264   4.733   3.058  1.00  0.00           N  
+ATOM     48  C4   DT B   3      -7.092   3.992   3.875  1.00  0.00           C  
+ATOM     49  O4   DT B   3      -8.104   3.455   3.421  1.00  0.00           O  
+ATOM     50  C5   DT B   3      -6.656   3.924   5.250  1.00  0.00           C  
+ATOM     51  C7   DT B   3      -7.500   3.137   6.208  1.00  0.00           C  
+ATOM     52  C6   DT B   3      -5.535   4.547   5.647  1.00  0.00           C  
+ATOM     53  H3   DT B   3      -6.521   4.804   2.140  1.00  0.00           H  
+ATOM     54 1H5'  DT B   3      -1.390   3.439   7.902  1.00  0.00           H  
+ATOM     55 2H5'  DT B   3      -2.334   2.913   6.487  1.00  0.00           H  
+ATOM     56  H4'  DT B   3      -0.717   4.966   6.278  1.00  0.00           H  
+ATOM     57  H3'  DT B   3      -1.996   6.231   8.215  1.00  0.00           H  
+ATOM     58 1H2'  DT B   3      -4.319   5.971   7.261  1.00  0.00           H  
+ATOM     59 2H2'  DT B   3      -3.850   7.577   6.654  1.00  0.00           H  
+ATOM     60  H1'  DT B   3      -3.351   6.721   4.462  1.00  0.00           H  
+ATOM     61  H71  DT B   3      -7.053   3.173   7.201  1.00  0.00           H  
+ATOM     62  H72  DT B   3      -8.503   3.564   6.246  1.00  0.00           H  
+ATOM     63  H73  DT B   3      -7.559   2.101   5.875  1.00  0.00           H  
+ATOM     64  H6   DT B   3      -5.239   4.475   6.684  1.00  0.00           H  
+ATOM     65  P    DT B   4      -6.361  -2.742   8.346  1.00  0.00           P  
+ATOM     66  OP1  DT B   4      -6.207  -2.712   9.817  1.00  0.00           O  
+ATOM     67  OP2  DT B   4      -7.750  -2.654   7.841  1.00  0.00           O1-
+ATOM     68  O5'  DT B   4      -5.472  -1.587   7.685  1.00  0.00           O  
+ATOM     69  C5'  DT B   4      -4.049  -1.777   7.577  1.00  0.00           C  
+ATOM     70  C4'  DT B   4      -3.342  -0.436   7.613  1.00  0.00           C  
+ATOM     71  O4'  DT B   4      -3.294   0.107   6.261  1.00  0.00           O  
+ATOM     72  C3'  DT B   4      -4.028   0.655   8.436  1.00  0.00           C  
+ATOM     73  O3'  DT B   4      -3.102   1.665   8.822  1.00  0.00           O  
+ATOM     74  C2'  DT B   4      -5.009   1.266   7.436  1.00  0.00           C  
+ATOM     75  C1'  DT B   4      -4.232   1.165   6.128  1.00  0.00           C  
+ATOM     76  N1   DT B   4      -5.087   0.877   4.943  1.00  0.00           N  
+ATOM     77  C2   DT B   4      -4.722   1.458   3.752  1.00  0.00           C  
+ATOM     78  O2   DT B   4      -3.747   2.180   3.639  1.00  0.00           O  
+ATOM     79  N3   DT B   4      -5.539   1.167   2.676  1.00  0.00           N  
+ATOM     80  C4   DT B   4      -6.661   0.365   2.692  1.00  0.00           C  
+ATOM     81  O4   DT B   4      -7.314   0.179   1.664  1.00  0.00           O  
+ATOM     82  C5   DT B   4      -6.963  -0.199   3.987  1.00  0.00           C  
+ATOM     83  C7   DT B   4      -8.169  -1.084   4.095  1.00  0.00           C  
+ATOM     84  C6   DT B   4      -6.186   0.066   5.050  1.00  0.00           C  
+ATOM     85  H3   DT B   4      -5.308   1.561   1.838  1.00  0.00           H  
+ATOM     86 1H5'  DT B   4      -3.700  -2.387   8.410  1.00  0.00           H  
+ATOM     87 2H5'  DT B   4      -3.818  -2.278   6.638  1.00  0.00           H  
+ATOM     88  H4'  DT B   4      -2.314  -0.576   7.946  1.00  0.00           H  
+ATOM     89  H3'  DT B   4      -4.387   0.231   9.373  1.00  0.00           H  
+ATOM     90 1H2'  DT B   4      -5.932   0.686   7.430  1.00  0.00           H  
+ATOM     91 2H2'  DT B   4      -5.228   2.294   7.724  1.00  0.00           H  
+ATOM     92  H1'  DT B   4      -3.706   2.086   5.872  1.00  0.00           H  
+ATOM     93  H71  DT B   4      -8.272  -1.435   5.122  1.00  0.00           H  
+ATOM     94  H72  DT B   4      -9.060  -0.522   3.812  1.00  0.00           H  
+ATOM     95  H73  DT B   4      -8.054  -1.940   3.429  1.00  0.00           H  
+ATOM     96  H6   DT B   4      -6.443  -0.373   6.004  1.00  0.00           H  
+ATOM     97  P    DT B   5      -8.225  -7.440   4.274  1.00  0.00           P  
+ATOM     98  OP1  DT B   5      -8.821  -7.893   5.551  1.00  0.00           O  
+ATOM     99  OP2  DT B   5      -9.183  -6.960   3.252  1.00  0.00           O1-
+ATOM    100  O5'  DT B   5      -7.129  -6.310   4.559  1.00  0.00           O  
+ATOM    101  C5'  DT B   5      -5.838  -6.702   5.064  1.00  0.00           C  
+ATOM    102  C4'  DT B   5      -5.245  -5.582   5.896  1.00  0.00           C  
+ATOM    103  O4'  DT B   5      -4.535  -4.665   5.014  1.00  0.00           O  
+ATOM    104  C3'  DT B   5      -6.250  -4.698   6.633  1.00  0.00           C  
+ATOM    105  O3'  DT B   5      -5.638  -4.033   7.735  1.00  0.00           O  
+ATOM    106  C2'  DT B   5      -6.608  -3.646   5.584  1.00  0.00           C  
+ATOM    107  C1'  DT B   5      -5.285  -3.472   4.846  1.00  0.00           C  
+ATOM    108  N1   DT B   5      -5.441  -3.226   3.385  1.00  0.00           N  
+ATOM    109  C2   DT B   5      -4.536  -2.378   2.793  1.00  0.00           C  
+ATOM    110  O2   DT B   5      -3.634  -1.837   3.409  1.00  0.00           O  
+ATOM    111  N3   DT B   5      -4.712  -2.175   1.438  1.00  0.00           N  
+ATOM    112  C4   DT B   5      -5.694  -2.736   0.647  1.00  0.00           C  
+ATOM    113  O4   DT B   5      -5.751  -2.478  -0.558  1.00  0.00           O  
+ATOM    114  C5   DT B   5      -6.595  -3.610   1.357  1.00  0.00           C  
+ATOM    115  C7   DT B   5      -7.695  -4.262   0.573  1.00  0.00           C  
+ATOM    116  C6   DT B   5      -6.448  -3.826   2.675  1.00  0.00           C  
+ATOM    117  H3   DT B   5      -4.096  -1.589   1.004  1.00  0.00           H  
+ATOM    118 1H5'  DT B   5      -5.945  -7.591   5.685  1.00  0.00           H  
+ATOM    119 2H5'  DT B   5      -5.171  -6.921   4.231  1.00  0.00           H  
+ATOM    120  H4'  DT B   5      -4.515  -5.994   6.594  1.00  0.00           H  
+ATOM    121  H3'  DT B   5      -7.026  -5.321   7.078  1.00  0.00           H  
+ATOM    122 1H2'  DT B   5      -7.406  -4.025   4.945  1.00  0.00           H  
+ATOM    123 2H2'  DT B   5      -6.944  -2.735   6.080  1.00  0.00           H  
+ATOM    124  H1'  DT B   5      -4.705  -2.623   5.208  1.00  0.00           H  
+ATOM    125  H71  DT B   5      -8.293  -4.889   1.234  1.00  0.00           H  
+ATOM    126  H72  DT B   5      -8.330  -3.494   0.129  1.00  0.00           H  
+ATOM    127  H73  DT B   5      -7.263  -4.876  -0.218  1.00  0.00           H  
+ATOM    128  H6   DT B   5      -7.141  -4.487   3.175  1.00  0.00           H  
+ATOM    129  HP   DT B   5      -7.696  -8.301   3.841  1.00  0.00           H  
+TER     130       DT B   5
+CONECT    1   41    2    3    4
+CONECT    1    2
+CONECT    2    1
+CONECT    2    1
+CONECT    3    1
+CONECT    4    1    5
+CONECT    5    4    6   21   22
+CONECT    6    5    7    8   23
+CONECT    7    6   10
+CONECT    8    6    9   24   32
+CONECT    9    8   10   25   26
+CONECT   10    7    9   11   27
+CONECT   11   10   12   19
+CONECT   12   11   13   14
+CONECT   12   13
+CONECT   13   12
+CONECT   13   12
+CONECT   14   12   15   20
+CONECT   15   14   16   17
+CONECT   15   16
+CONECT   16   15
+CONECT   16   15
+CONECT   17   15   18   19
+CONECT   17   19
+CONECT   18   17   28   29   30
+CONECT   19   11   17   31
+CONECT   19   17
+CONECT   20   14
+CONECT   21    5
+CONECT   22    5
+CONECT   23    6
+CONECT   24    8
+CONECT   25    9
+CONECT   26    9
+CONECT   27   10
+CONECT   28   18
+CONECT   29   18
+CONECT   30   18
+CONECT   31   19
+CONECT   33   73   34   35   36
+CONECT   33   34
+CONECT   34   33
+CONECT   34   33
+CONECT   35   33
+CONECT   36   33   37
+CONECT   37   36   38   54   55
+CONECT   38   37   39   40   56
+CONECT   39   38   43
+CONECT   40   38   41   42   57
+CONECT   41    1   40
+CONECT   42   40   43   58   59
+CONECT   43   39   42   44   60
+CONECT   44   43   45   52
+CONECT   45   44   46   47
+CONECT   45   46
+CONECT   46   45
+CONECT   46   45
+CONECT   47   45   48   53
+CONECT   48   47   49   50
+CONECT   48   49
+CONECT   49   48
+CONECT   49   48
+CONECT   50   48   51   52
+CONECT   50   52
+CONECT   51   50   61   62   63
+CONECT   52   44   50   64
+CONECT   52   50
+CONECT   53   47
+CONECT   54   37
+CONECT   55   37
+CONECT   56   38
+CONECT   57   40
+CONECT   58   42
+CONECT   59   42
+CONECT   60   43
+CONECT   61   51
+CONECT   62   51
+CONECT   63   51
+CONECT   64   52
+CONECT   65  105   66   67   68
+CONECT   65   66
+CONECT   66   65
+CONECT   66   65
+CONECT   67   65
+CONECT   68   65   69
+CONECT   69   68   70   86   87
+CONECT   70   69   71   72   88
+CONECT   71   70   75
+CONECT   72   70   73   74   89
+CONECT   73   33   72
+CONECT   74   72   75   90   91
+CONECT   75   71   74   76   92
+CONECT   76   75   77   84
+CONECT   77   76   78   79
+CONECT   77   78
+CONECT   78   77
+CONECT   78   77
+CONECT   79   77   80   85
+CONECT   80   79   81   82
+CONECT   80   81
+CONECT   81   80
+CONECT   81   80
+CONECT   82   80   83   84
+CONECT   82   84
+CONECT   83   82   93   94   95
+CONECT   84   76   82   96
+CONECT   84   82
+CONECT   85   79
+CONECT   86   69
+CONECT   87   69
+CONECT   88   70
+CONECT   89   72
+CONECT   90   74
+CONECT   91   74
+CONECT   92   75
+CONECT   93   83
+CONECT   94   83
+CONECT   95   83
+CONECT   96   84
+CONECT   97   98   99  100  129
+CONECT   97   98
+CONECT   98   97
+CONECT   98   97
+CONECT   99   97
+CONECT  100   97  101
+CONECT  101  100  102  118  119
+CONECT  102  101  103  104  120
+CONECT  103  102  107
+CONECT  104  102  105  106  121
+CONECT  105   65  104
+CONECT  106  104  107  122  123
+CONECT  107  103  106  108  124
+CONECT  108  107  109  116
+CONECT  109  108  110  111
+CONECT  109  110
+CONECT  110  109
+CONECT  110  109
+CONECT  111  109  112  117
+CONECT  112  111  113  114
+CONECT  112  113
+CONECT  113  112
+CONECT  113  112
+CONECT  114  112  115  116
+CONECT  114  116
+CONECT  115  114  125  126  127
+CONECT  116  108  114  128
+CONECT  116  114
+CONECT  117  111
+CONECT  118  101
+CONECT  119  101
+CONECT  120  102
+CONECT  121  104
+CONECT  122  106
+CONECT  123  106
+CONECT  124  107
+CONECT  125  115
+CONECT  126  115
+CONECT  127  115
+CONECT  128  116
+CONECT  129   97
+CONECT   32    8
+END   

--- a/HEG.pdb
+++ b/HEG.pdb
@@ -1,0 +1,93 @@
+REMARK   4      COMPLIES WITH FORMAT V. 3.0, 1-DEC-2006
+REMARK 888
+REMARK 888 WRITTEN BY MAESTRO (A PRODUCT OF SCHRODINGER, LLC)
+TITLE     HEG
+MODEL        1
+HETATM    1  O1  HEG     1      21.374   6.419 -10.628  1.00  0.00           O  
+HETATM    2  C1  HEG     1      20.343   7.130  -9.954  1.00  0.00           C  
+HETATM    3  C2  HEG     1      20.637   4.105 -10.419  1.00  0.00           C  
+HETATM    4  C3  HEG     1      19.221   7.442 -10.952  1.00  0.00           C  
+HETATM    5  O2  HEG     1      20.990   2.858  -9.841  1.00  0.00           O  
+HETATM    6  C4  HEG     1      20.074   1.825 -10.157  1.00  0.00           C  
+HETATM    7  C5  HEG     1      21.699   5.157 -10.061  1.00  0.00           C  
+HETATM    8  C6  HEG     1      20.548   0.538  -9.474  1.00  0.00           C  
+HETATM    9  O3  HEG     1      19.657  -0.527  -9.785  1.00  0.00           O  
+HETATM   10  C7  HEG     1      20.041  -1.756  -9.183  1.00  0.00           C  
+HETATM   11  C8  HEG     1      19.080  -2.864  -9.557  1.00  0.00           C  
+HETATM   12  O4  HEG     1      18.041   7.782 -10.239  1.00  0.00           O  
+HETATM   13  C9  HEG     1      16.955   8.099 -11.091  1.00  0.00           C  
+HETATM   14  C10 HEG     1      15.743   8.428 -10.212  1.00  0.00           C  
+HETATM   15  O5  HEG     1      14.616   8.715 -11.031  1.00  0.00           O  
+HETATM   16  C11 HEG     1      13.457   9.044 -10.278  1.00  0.00           C  
+HETATM   17  C12 HEG     1      12.302   9.390 -11.191  1.00  0.00           C  
+HETATM   18  H1  HEG     1      20.749   8.052  -9.538  1.00  0.00           H  
+HETATM   19  H2  HEG     1      19.940   6.563  -9.113  1.00  0.00           H  
+HETATM   20  H3  HEG     1      20.567   4.012 -11.505  1.00  0.00           H  
+HETATM   21  H4  HEG     1      19.656   4.411 -10.054  1.00  0.00           H  
+HETATM   22  H5  HEG     1      19.024   6.562 -11.565  1.00  0.00           H  
+HETATM   23  H6  HEG     1      19.527   8.246 -11.623  1.00  0.00           H  
+HETATM   24  H7  HEG     1      20.027   1.682 -11.238  1.00  0.00           H  
+HETATM   25  H8  HEG     1      19.072   2.087  -9.812  1.00  0.00           H  
+HETATM   26  H9  HEG     1      21.833   5.239  -8.981  1.00  0.00           H  
+HETATM   27  H10 HEG     1      22.661   4.844 -10.467  1.00  0.00           H  
+HETATM   28  H11 HEG     1      20.592   0.692  -8.395  1.00  0.00           H  
+HETATM   29  H12 HEG     1      21.557   0.296  -9.812  1.00  0.00           H  
+HETATM   30  H13 HEG     1      20.057  -1.656  -8.096  1.00  0.00           H  
+HETATM   31  H14 HEG     1      21.044  -2.038  -9.507  1.00  0.00           H  
+HETATM   32  H15 HEG     1      18.866  -2.961 -10.611  1.00  0.00           H  
+HETATM   33  H16 HEG     1      16.729   7.255 -11.743  1.00  0.00           H  
+HETATM   34  H17 HEG     1      17.206   8.952 -11.723  1.00  0.00           H  
+HETATM   35  H18 HEG     1      15.977   9.283  -9.574  1.00  0.00           H  
+HETATM   36  H19 HEG     1      15.525   7.582  -9.557  1.00  0.00           H  
+HETATM   37  H20 HEG     1      13.655   9.894  -9.624  1.00  0.00           H  
+HETATM   38  H21 HEG     1      13.166   8.200  -9.650  1.00  0.00           H  
+HETATM   39  H22 HEG     1      11.421   9.787 -10.710  1.00  0.00           H  
+HETATM   40  H23 HEG     1      18.147  -2.730  -9.010  1.00  0.00           H  
+HETATM   41  H24 HEG     1      19.460  -3.812  -9.178  1.00  0.00           H  
+HETATM   42  H25 HEG     1      12.028   8.511 -11.774  1.00  0.00           H  
+HETATM   43  H26 HEG     1      12.643  10.092 -11.952  1.00  0.00           H  
+CONECT    1    7    2
+CONECT    2    1    4   18   19
+CONECT    3    7    5   20   21
+CONECT    4    2   12   22   23
+CONECT    5    3    6
+CONECT    6    5    8   24   25
+CONECT    7    1    3   26   27
+CONECT    8    6    9   28   29
+CONECT    9    8   10
+CONECT   10    9   11   30   31
+CONECT   11   10   32   40   41
+CONECT   12    4   13
+CONECT   13   12   14   33   34
+CONECT   14   13   15   35   36
+CONECT   15   14   16
+CONECT   16   15   17   37   38
+CONECT   17   16   39   42   43
+CONECT   18    2
+CONECT   19    2
+CONECT   20    3
+CONECT   21    3
+CONECT   22    4
+CONECT   23    4
+CONECT   24    6
+CONECT   25    6
+CONECT   26    7
+CONECT   27    7
+CONECT   28    8
+CONECT   29    8
+CONECT   30   10
+CONECT   31   10
+CONECT   32   11
+CONECT   33   13
+CONECT   34   13
+CONECT   35   14
+CONECT   36   14
+CONECT   37   16
+CONECT   38   16
+CONECT   39   17
+CONECT   40   11
+CONECT   41   11
+CONECT   42   17
+CONECT   43   17
+ENDMDL
+END   

--- a/benzene.pdb
+++ b/benzene.pdb
@@ -1,0 +1,89 @@
+REMARK   4      COMPLIES WITH FORMAT V. 3.0, 1-DEC-2006
+REMARK 888
+REMARK 888 WRITTEN BY MAESTRO (A PRODUCT OF SCHRODINGER, LLC)
+TITLE     Structure1
+MODEL        1
+HETATM    1  C1  UNK     1       1.405  -0.000   0.000  1.00  0.00           C  
+HETATM    2  C2  UNK     1       0.702   1.216   0.000  1.00  0.00           C  
+HETATM    3  C3  UNK     1      -0.702   1.216   0.000  1.00  0.00           C  
+HETATM    4  C4  UNK     1      -1.404  -0.000   0.000  1.00  0.00           C  
+HETATM    5  C5  UNK     1      -0.702  -1.216   0.000  1.00  0.00           C  
+HETATM    6  C6  UNK     1       0.702  -1.216   0.000  1.00  0.00           C  
+HETATM    7  C7  UNK     1       2.838  -4.916   0.000  1.00  0.00           C  
+HETATM    8  C8  UNK     1       1.434  -4.916   0.000  1.00  0.00           C  
+HETATM    9  C9  UNK     1       0.731  -3.700   0.000  1.00  0.00           C  
+HETATM   10  C10 UNK     1       1.434  -2.483   0.000  1.00  0.00           C  
+HETATM   11  C11 UNK     1       2.838  -2.483   0.000  1.00  0.00           C  
+HETATM   12  C12 UNK     1       3.541  -3.700   0.000  1.00  0.00           C  
+HETATM   13  C13 UNK     1      -5.676  -0.000   0.000  1.00  0.00           C  
+HETATM   14  C14 UNK     1      -4.974  -1.216   0.000  1.00  0.00           C  
+HETATM   15  C15 UNK     1      -3.570  -1.216   0.000  1.00  0.00           C  
+HETATM   16  C16 UNK     1      -2.867  -0.000   0.000  1.00  0.00           C  
+HETATM   17  C17 UNK     1      -3.570   1.216   0.000  1.00  0.00           C  
+HETATM   18  C18 UNK     1      -4.974   1.216   0.000  1.00  0.00           C  
+HETATM   19  H1  UNK     1       2.508  -0.000   0.000  1.00  0.00           H  
+HETATM   20  H2  UNK     1       1.254   2.172   0.000  1.00  0.00           H  
+HETATM   21  H3  UNK     1      -1.254   2.172   0.000  1.00  0.00           H  
+HETATM   22  H4  UNK     1      -1.254  -2.172   0.000  1.00  0.00           H  
+HETATM   23  H5  UNK     1       3.390  -5.872   0.000  1.00  0.00           H  
+HETATM   24  H6  UNK     1       0.882  -5.872   0.000  1.00  0.00           H  
+HETATM   25  H7  UNK     1      -0.372  -3.700   0.000  1.00  0.00           H  
+HETATM   26  H8  UNK     1       3.390  -1.528   0.000  1.00  0.00           H  
+HETATM   27  H9  UNK     1       4.644  -3.700   0.000  1.00  0.00           H  
+HETATM   28  H10 UNK     1      -6.780  -0.000   0.000  1.00  0.00           H  
+HETATM   29  H11 UNK     1      -5.526  -2.172   0.000  1.00  0.00           H  
+HETATM   30  H12 UNK     1      -3.018  -2.172   0.000  1.00  0.00           H  
+HETATM   31  H13 UNK     1      -3.018   2.172   0.000  1.00  0.00           H  
+HETATM   32  H14 UNK     1      -5.526   2.172   0.000  1.00  0.00           H  
+CONECT    1    2    6   19
+CONECT    1    2
+CONECT    2    1    3   20
+CONECT    2    1
+CONECT    3    2    4   21
+CONECT    3    4
+CONECT    4    3    5   16
+CONECT    4    3
+CONECT    5    4    6   22
+CONECT    5    6
+CONECT    6    1    5   10
+CONECT    6    5
+CONECT   19    1
+CONECT   20    2
+CONECT   21    3
+CONECT   22    5
+CONECT    7    8   12   23
+CONECT    7    8
+CONECT    8    7    9   24
+CONECT    8    7
+CONECT    9    8   10   25
+CONECT    9   10
+CONECT   10    6    9   11
+CONECT   10    9
+CONECT   11   10   12   26
+CONECT   11   12
+CONECT   12    7   11   27
+CONECT   12   11
+CONECT   23    7
+CONECT   24    8
+CONECT   25    9
+CONECT   26   11
+CONECT   27   12
+CONECT   13   14   18   28
+CONECT   13   14
+CONECT   14   13   15   29
+CONECT   14   13
+CONECT   15   14   16   30
+CONECT   15   16
+CONECT   16    4   15   17
+CONECT   16   15
+CONECT   17   16   18   31
+CONECT   17   18
+CONECT   18   13   17   32
+CONECT   18   17
+CONECT   28   13
+CONECT   29   14
+CONECT   30   15
+CONECT   31   17
+CONECT   32   18
+ENDMDL
+END   

--- a/linkerInformation.toml
+++ b/linkerInformation.toml
@@ -1,0 +1,29 @@
+[[HEG]]
+	file = "linkers/HEG.pdb"
+	linkerS = 1
+	linkerSName = "C8"
+	linkerSResnum = 1
+	linkerE = 17
+	linkerEName = "C12"
+	linkerEResnum = 1
+	linkerCenter = "O1"
+
+[[4T]]
+        file = "linkers/4T_no_3prime_phosphate.pdb"
+        linkerS = 8 # looks like an atom index
+        linkerSName = "C3'" # atom.pdbname
+        linkerSResnum = 2 
+        linkerE = 96
+        linkerEName = "P"
+        linkerEResnum = 5
+        linkerCenter = "P*"
+
+[[benzene]]
+	file = "linkers/benzene.pdb"
+	linkerS = 7
+	linkerSName = "C7"
+	linkerSResnum = 1
+	linkerE = 13
+	linkerEName = "C13"
+	linkerEResnum = 1
+	linkerCenter = "C5"


### PR DESCRIPTION
DNA-BACon connects one end of a linker to an oxygen atom in the 5' phosphate of the first base in the pillar, so the connecting atom in the linker should not be O (meaning that alcohol or phosphate groups might need to be removed). On the other pillar, the 3' oxygen of the last base connects to whatever atom is specified in the linker. A good choice might be PO3H, where the H is bonded directly to P. The O in the pillar can then be attached to P and the program will naturally remove the H, resulting in a normal phosphate connecting the rest of the linker to the DNA. In this edit, I fixed the predefined linker PDB files and their descriptions in the linkerInformation.toml configuration file to produce more reasonable connection behavior. 

However, DNA-BACon still does not check the chirality of the last linker atom after being connected to the pillar